### PR TITLE
Fix method name conflict with Laravel 13

### DIFF
--- a/.changeset/clever-pandas-rest.md
+++ b/.changeset/clever-pandas-rest.md
@@ -1,0 +1,5 @@
+---
+"actengage-sluggable": patch
+---
+
+Fix method name conflict with Laravel 13's `Model::resolveClassAttribute()` by renaming to `resolveSluggableAttribute()`

--- a/src/Sluggable.php
+++ b/src/Sluggable.php
@@ -22,7 +22,7 @@ trait Sluggable
      * @param  class-string<T>  $attributeClass
      * @return T|null
      */
-    protected function resolveClassAttribute(string $attributeClass): ?object
+    protected function resolveSluggableAttribute(string $attributeClass): ?object
     {
         $reflection = new ReflectionClass($this);
         $attributes = $reflection->getAttributes($attributeClass);
@@ -49,7 +49,7 @@ trait Sluggable
      */
     public function preventDuplicateSlugs(): bool
     {
-        $attribute = $this->resolveClassAttribute(PreventDuplicateSlugs::class);
+        $attribute = $this->resolveSluggableAttribute(PreventDuplicateSlugs::class);
 
         if ($attribute !== null) {
             return $attribute->enabled;
@@ -65,7 +65,7 @@ trait Sluggable
      */
     public function getSlugDelimiter(): string
     {
-        $attribute = $this->resolveClassAttribute(SlugDelimiter::class);
+        $attribute = $this->resolveSluggableAttribute(SlugDelimiter::class);
 
         return $attribute !== null ? $attribute->delimiter : '-';
     }
@@ -75,7 +75,7 @@ trait Sluggable
      */
     public function getSlugAttributeName(): string
     {
-        $attribute = $this->resolveClassAttribute(SlugAttribute::class);
+        $attribute = $this->resolveSluggableAttribute(SlugAttribute::class);
 
         return $attribute !== null ? $attribute->name : 'slug';
     }
@@ -85,7 +85,7 @@ trait Sluggable
      */
     public function getSlugQualifierAttributeName(): string
     {
-        $attribute = $this->resolveClassAttribute(Slug::class);
+        $attribute = $this->resolveSluggableAttribute(Slug::class);
 
         return $attribute !== null ? $attribute->qualifier : 'title';
     }


### PR DESCRIPTION
## Summary
- Rename `resolveClassAttribute()` to `resolveSluggableAttribute()` to avoid conflict with Laravel 13's `Model::resolveClassAttribute()` static method

## Test plan
- [ ] Verify all tests pass with Laravel 13
- [ ] Verify `v7.0.1` is released after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)